### PR TITLE
perf: :rotating_light: Adds use of `===` and `!==` for .js files. 

### DIFF
--- a/script.js
+++ b/script.js
@@ -41,7 +41,7 @@ document.querySelector(".search button").addEventListener("click", function() {
 document
     .querySelector(".search-bar")
     .addEventListener("keyup", function(event) {
-        if (event.key == "Enter") {
+        if (event.key === "Enter") {
             weather.search();
         }
     });


### PR DESCRIPTION
Deprecating the use of `==` and `!=` for JavaScript.

Good practice to use type-safety equality operators `===` and `!==` instead of  the regular `==` and `!=`. 
For example, it could be a problem if the regular occurs in `a == b` as it's hard to spot. 

> "The most notable difference between this operator and the equality (==) operator is that if the operands are of different types, the == operator attempts to convert them to the same type before comparing." 
> Reference - "JS-0050" — Deepsource